### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.filerepresentation
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,17 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 
 4.1.0 (2014-12-27)
-------------------
+==================
 
 - Add support for PyPy3.
 
@@ -18,32 +19,32 @@ Changes
 
 
 4.0.2 (2013-03-08)
-------------------
+==================
 
 - Add Trove classifiers indicating CPython and PyPy support.
 
 
 4.0.1 (2013-02-11)
-------------------
+==================
 
 - Add tox.ini to release.
 
 
 4.0.0 (2013-02-11)
-------------------
+==================
 
 - Add support for Python 3.3 and PyPy.
 
 - Drop support for Python 2.4 / 2.5.
 
 3.6.1 (2011-11-29)
-------------------
+==================
 
 - Add undeclared ``zope.schema`` dependency.
 - Remove ``zope.testing`` test dependency and ``test`` extra.
 
 3.6.0 (2009-10-08)
-------------------
+==================
 
 - Add `IRawReadFile` and `IRawWriteFile` interfaces. These extend
   `IReadFile` and `IWritefile`, respectively, to behave pretty much like a
@@ -55,11 +56,11 @@ Changes
   and ``zope.interface.common.mapping``.
 
 3.5.0 (2009-01-31)
-------------------
+==================
 
 - Change use of ``zope.app.container`` to ``zope.container``.
 
 3.4.0 (2007-10-02)
-------------------
+==================
 
 - Initial Zope-independent release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,15 @@
 include *.rst
 include *.txt
 include tox.ini
+include .travis.yml
+include .coveragerc
 include bootstrap.py
 include buildout.cfg
 
 recursive-include src *
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+
 
 global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,28 @@
-``zope.filerepresentation``
-===========================
+=============================
+ ``zope.filerepresentation``
+=============================
+
+.. image:: https://img.shields.io/pypi/v/zope.filerepresentation.svg
+        :target: https://pypi.python.org/pypi/zope.filerepresentation/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.filerepresentation.svg
+        :target: https://pypi.org/project/zope.filerepresentation/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.filerepresentation.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.filerepresentation
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.filerepresentation/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.filerepresentation?branch=master
+
 .. image:: https://readthedocs.org/projects/zopefilerepresentation/badge/?version=latest
-         :target: http://zopefilerepresentation.readthedocs.io/en/latest/?badge=latest
-         :alt: Documentation Status
+        :target: https://zopefilerepresentation.readthedocs.io/en/latest/
+        :alt: Documentation Status
 
 
 The interfaces defined here are used for file-system and file-system-like
 representations of objects, such as file-system synchronization, FTP, PUT, and
 WebDAV.
+
+Documentation is hosted at https://zopefilerepresentation.readthedocs.io/

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ cover-min-percentage=100
 with-doctest=0
 where=src
 
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -25,45 +25,53 @@ def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
-setup(name='zope.filerepresentation',
-      version=read('version.txt').strip(),
-      author='Zope Corporation and Contributors',
-      author_email='zope-dev@zope.org',
-      description='File-system Representation Interfaces',
-      long_description=(
-          read('README.rst')
-          + '\n\n' +
-          read('CHANGES.rst')
-          ),
-      keywords="zope3 filesystem representation",
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Web Environment',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Zope Public License',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
-          'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Programming Language :: Python :: Implementation :: PyPy',
-          'Natural Language :: English',
-          'Operating System :: OS Independent',
-          'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://zopefilerepresentation.readthedocs.io',
-      license='ZPL 2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
-      install_requires=['setuptools',
-                        'zope.interface',
-                        'zope.schema',
-                        ],
-      include_package_data=True,
-      test_suite='zope.filerepresentation.tests.test_suite',
-      zip_safe=True,
-      )
+setup(
+    name='zope.filerepresentation',
+    version=read('version.txt').strip(),
+    author='Zope Corporation and Contributors',
+    author_email='zope-dev@zope.org',
+    description='File-system Representation Interfaces',
+    long_description=(
+        read('README.rst')
+        + '\n\n' +
+        read('CHANGES.rst')
+    ),
+    keywords="zope3 filesystem representation",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Zope Public License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Topic :: Internet :: WWW/HTTP',
+        'Framework :: Zope3',
+    ],
+    url='http://zopefilerepresentation.readthedocs.io',
+    license='ZPL 2.1',
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    namespace_packages=['zope'],
+    install_requires=[
+        'setuptools',
+        'zope.interface',
+        'zope.schema',
+    ],
+    extras_require={
+        'test': [
+            'zope.testrunner',
+        ],
+    },
+    include_package_data=True,
+    test_suite='zope.filerepresentation.tests.test_suite',
+    zip_safe=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,11 @@ setup(
         'test': [
             'zope.testrunner',
         ],
+        'docs': [
+            'Sphinx',
+            'repoze.sphinx.autointerface',
+            'sphinx_rtd_theme',
+        ],
     },
     include_package_data=True,
     test_suite='zope.filerepresentation.tests.test_suite',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/filerepresentation/interfaces.py
+++ b/src/zope/filerepresentation/interfaces.py
@@ -17,13 +17,13 @@ synchronization, FTP, PUT, and WebDAV.
 
 There are three issues we need to deal with:
 
-  File system representation
+* File system representation
 
     Every object is either a directory or a file.
 
-  Properties
+* Properties
 
-    There are two kinds of proprties:
+    There are two kinds of properties:
 
     - Data properties
 
@@ -33,7 +33,7 @@ There are three issues we need to deal with:
 
       Meta data properties are handled via annotations.
 
-  Completeness
+* Completeness
 
     We must have a complete lossless data representation for file-system
     synchronization. This is achieved through serialization of:
@@ -42,11 +42,11 @@ There are three issues we need to deal with:
 
     - Extra data.
 
-  Strategies for common access mechanisms:
+Strategies for common access mechanisms:
 
-    FTP
+* FTP
 
-      - For getting directory info (statish) information:
+    For getting directory info (statish) information:
 
         - Use Zope DublinCore to get modification times
 
@@ -54,32 +54,32 @@ There are three issues we need to deal with:
 
         - Show as writable if we can access a write method.
 
-    FTP and WebDAV
+* FTP and WebDAV
 
-      - Treat as a directory if there is an adapter to `IReadDirectory`.
-        Treat as a file otherwise.
+    - Treat as a directory if there is an adapter to :class:`IReadDirectory`.
+      Treat as a file otherwise.
 
-      - For creating objects:
+    - For creating objects:
 
         - Directories:
 
-          Look for an `IDirectoryFactory` adapter.
+          Look for an :class:`IDirectoryFactory` adapter.
 
         - Files
 
-          First lookj for a `IFileFactory` adapter with a name that is
+          First look for a :class:`IFileFactory` adapter with a name that is
           the same as the extention (e.g. ".pt").
 
-          Then look for an unnamed `IFileFactory` adapter.
+          Then look for an unnamed :class:`IFileFactory` adapter.
 
 
-    File-system synchronization
+* File-system synchronization
 
       Because this must be lossless, we will use class-based adapters
       for this, but we want to make it as easy as possible to use other
       adapters as well.
 
-      For reading, there must be a class adapter to `IReadSync`.  We will
+      For reading, there must be a class adapter to :class:`IReadSync`.  We will
       then apply rules similar to those above.
 """
 __docformat__ = 'restructuredtext'
@@ -87,8 +87,9 @@ __docformat__ = 'restructuredtext'
 from zope.interface import Interface
 from zope import schema
 
-from zope.interface.common.mapping import IEnumerableMapping, IItemMapping, \
-    IReadMapping
+from zope.interface.common.mapping import IEnumerableMapping
+from zope.interface.common.mapping import IItemMapping
+from zope.interface.common.mapping import IReadMapping
 
 
 class IReadFile(Interface):
@@ -115,36 +116,36 @@ class ICommonFileOperations(Interface):
     """
 
     mimeType = schema.ASCIILine(
-            title=u"File MIME type",
-            description=u"Provided if it makes sense for this file data. "    +
-                        u"May be set prior to writing data to a file that " +
-                        u"is writeable. It is an error to set this on a "   +
-                        u"file that is not writable.",
-            readonly=True,
-        )
+        title=u"File MIME type",
+        description=(u"Provided if it makes sense for this file data. "
+                     u"May be set prior to writing data to a file that "
+                     u"is writeable. It is an error to set this on a "
+                     u"file that is not writable."),
+        readonly=True,
+    )
 
     encoding = schema.Bool(
-            title=u"The encoding that this file uses",
-            description=u"Provided if it makes sense for this file data. "    +
-                        u"May be set prior to writing data to a file that " +
-                        u"is writeable. It is an error to set this on a "   +
-                        u"file that is not writable.",
-            required=False,
-        )
+        title=u"The encoding that this file uses",
+        description=(u"Provided if it makes sense for this file data. "
+                     u"May be set prior to writing data to a file that "
+                     u"is writeable. It is an error to set this on a "
+                     u"file that is not writable."),
+        required=False,
+    )
 
     closed = schema.Bool(
-            title=u"Is the file closed?",
-            required=True,
-        )
+        title=u"Is the file closed?",
+        required=True,
+    )
 
     name = schema.TextLine(
-            title=u"A representative file name",
-            description=u"Provided if it makes sense for this file data. "    +
-                        u"May be set prior to writing data to a file that " +
-                        u"is writeable. It is an error to set this on a "   +
-                        u"file that is not writable.",
-            required=False,
-        )
+        title=u"A representative file name",
+        description=(u"Provided if it makes sense for this file data. "
+                     u"May be set prior to writing data to a file that "
+                     u"is writeable. It is an error to set this on a "
+                     u"file that is not writable."),
+        required=False,
+    )
 
     def seek(offset, whence=None):
         """Seek the file. See Python documentation for :class:`io.IOBase` for

--- a/src/zope/filerepresentation/tests.py
+++ b/src/zope/filerepresentation/tests.py
@@ -22,7 +22,4 @@ class Test(unittest.TestCase):
         from zope.filerepresentation import interfaces
 
 def test_suite():
-    loader=unittest.TestLoader()
-    return unittest.TestSuite((
-        loader.loadTestsFromTestCase(Test),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-   py27,py34,py35,py36,pypy,pypy3,coverage
+   py27,py34,py35,py36,pypy,pypy3,coverage,docs
 
 [testenv]
 commands =
@@ -18,3 +18,9 @@ commands =
 deps =
     {[testenv]deps}
     coverage
+
+[testenv:docs]
+commands =
+    sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+deps =
+    .[docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,coverage
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
+    zope-testrunner --test-path=src []
 deps =
-    zope.interface
-    zope.schema
+    .[test]
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src
+    coverage report --fail-under=100
 deps =
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover


### PR DESCRIPTION
- Badges
- Enable coveralls and require 100% coverage
- Use zope.testrunner because of namespace path issues on 3.5+
- Add a tox environment for docs and tweak indentation in interfaces.py for slightly better rendering and simplicity.